### PR TITLE
Ensure that we cannot proceed if outpath is '.' (cwd/root); bump version

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "docpad-plugin-ghpages",
-	"version": "2.0.2",
+	"version": "2.0.3",
 	"description": "Deploy to Github Pages easily via `docpad deploy-ghpages`",
 	"homepage": "http://docpad.org/plugin/ghpages",
 	"keywords": [

--- a/src/ghpages.plugin.coffee
+++ b/src/ghpages.plugin.coffee
@@ -39,6 +39,7 @@ module.exports = (BasePlugin) ->
 
 					# Prepare
 					outPath = docpad.config.outPath
+					return next("Cannot have config.outPath be repo root directory '.'") if outPath is '' or outPath is '.' or outPath is './'
 					outGitPath = pathUtil.join(outPath,'.git')
 
 					# Remove the out git repo if it exists


### PR DESCRIPTION
Per https://github.com/docpad/docpad-plugin-ghpages/issues/6 deploy-ghpages fails if outPath is set to '.', because it removes .git, etc. The right way to do it is to output to ./out, push that to ghpages, then clean it up, which is how it does it.

Net: this is just a safety check. If not, it might fail _and_ wipe out a user's .git directory.
