### PR TITLE
add ghpRoot attribute handling

### DIFF
--- a/src/ghpages.plugin.coffee
+++ b/src/ghpages.plugin.coffee
@@ -23,7 +23,11 @@ module.exports = (BasePlugin) ->
 			# Prepare
 			docpad = @docpad
 			config = @getConfig()
-			{outPath,rootPath} = docpad.getConfig()
+			{outPath,rootPath, ghpRoot} = docpad.getConfig()
+
+			if ghpRoot
+				outPath = outPath + '/' + ghpRoot
+
 			opts = {}
 
 			# Log
@@ -38,8 +42,7 @@ module.exports = (BasePlugin) ->
 				if outPath is rootPath
 					err = new Error("Your outPath configuration has been customised. Please remove the customisation in order to use the GitHub Pages plugin")
 					return next(err)
-
-				# Apply
+				
 				opts.outGitPath = pathUtil.join(outPath, '.git')
 
 				# Complete


### PR DESCRIPTION
creating a project site it will automatically be placed in a subfolder like

paddelkraft.github.io/projname

being able to run docpad with the same offset http://localhost:9778/projname/ and mark subdirectory  projname as the root  for github pages like this 

  outPath: 'out'  # default
  ghpRoot: 'in5'

makes it possible to use the same internal links in md files and layouts without needing do do any templating which is really nice.
